### PR TITLE
fix: invariant prints the error string

### DIFF
--- a/src/invariant.php
+++ b/src/invariant.php
@@ -23,7 +23,7 @@ namespace {
 	  string $format_str,
 	  ...$fmt_args
 	) {
-		throw new \HH\InvariantException(printf($format_str, ...$fmt_args));
+		throw new \HH\InvariantException(sprintf($format_str, ...$fmt_args));
 	}
 }
 


### PR DESCRIPTION
1 little s was missing before (s)printf()